### PR TITLE
Better handle special characters in passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ The above command will export all public links from selected del.icio.us account
 
 ### Export all links, including private:
 
-`./export.rb -u USERNAME -p PASSWORD -o bookmarks.html`
+`./export.rb -u USERNAME -p 'PASSWORD' -o bookmarks.html`
 
 If you provide a password, the script will attempt to login on your behalf and export all links, including those marked as private. To make it easier to identify private links later, the script adds a special tag to them: *___private*.
+
+Don't forget to enclose the password in single quotes if it contains any characters that may confuse your shell.
 
 ### Export only valid links
 

--- a/export.rb
+++ b/export.rb
@@ -20,7 +20,7 @@ def parse_options
       options[:username] = u
     end
     
-    opts.on("-p", "--password DELICIOUS_PASSWORD", "Delicious password. If you don't provide it, only public bookmarks will be exported.") do |p|
+    opts.on("-p", "--password 'DELICIOUS_PASSWORD'", "Delicious password, in single quotes. If you don't provide it, only public bookmarks will be exported.") do |p|
       options[:password] = p
     end
   
@@ -96,7 +96,7 @@ end
 
 def login(tmpdir, username, password)
   cookie_file = "#{tmpdir}/cookie.txt"
-  query = %Q{curl -s -c #{cookie_file} -d "username=#{username}" -d "password=#{password}" "https://del.icio.us/login"}
+  query = %Q{curl -s -c #{cookie_file} -d 'username=#{username}' --data-urlencode 'password=#{password}' "https://del.icio.us/login"}
   response_str = `#{query}`
   check_status($?, query)
   response = JSON.parse(response_str)


### PR DESCRIPTION
Fixes #5. 

Better handle special characters in passwords, like & and $, so they’re not interpreted by the shell. Required when an account has a complex password that contains characters like this.

The important things are two changes in line 99 of the script: use single quotes and urlencode the POST data.

The rest of the changes are documentation.