### PR TITLE
Retry validation on transient errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ If you provide a password, the script will attempt to login on your behalf and e
 When you provide `--validate` option, the script will try to fix or skip dead links:
 
 1. If the server doesn't respond within 5 seconds, the link will be skipped.
-2. If the server sends a redirect header, the script will follow it and save the target URL.
+2. If the server responds with a transient error (timeout or 5xx error) the script will retry up to 3 times, then skip the link.
+3. If the server sends a redirect header, the script will follow it and save the target URL.
 
 This mode is much slower and can take about 2 minutes for every hundred links.
 

--- a/export.rb
+++ b/export.rb
@@ -67,7 +67,7 @@ def check_status(status, query)
 end
 
 def http_status(url)
-  `curl -Is --connect-timeout 5 '#{url}' | head -n 1`.chomp
+  `curl -Is --connect-timeout 5 --retry 3 '#{url}' | head -n 1`.chomp
 end
 
 def url(el)


### PR DESCRIPTION
While validating links, let Curl retry a few times on transient errors, like timeouts or HTTP 5xx errors.

Won't help much since most transient errors won't be resolved in the few seconds that the retries take. On the other hand, it doesn't take much time and may prevent discarding a few links prematurely.